### PR TITLE
#155552363 add confirm functionality to delete action

### DIFF
--- a/client/src/components/recipes/HomePage.jsx
+++ b/client/src/components/recipes/HomePage.jsx
@@ -80,10 +80,11 @@ class HomePage extends Component {
 HomePage.propTypes = {
   fetchRecipes: PropTypes.func.isRequired,
   recipes: PropTypes.array,
-  pages: PropTypes.number.isRequired
+  pages: PropTypes.number
 };
 HomePage.defaultProps = {
   recipes: [],
+  pages: 1
 };
 
 const mapStateToProps = state => ({

--- a/client/src/components/recipes/UserRecipesPage.jsx
+++ b/client/src/components/recipes/UserRecipesPage.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { confirmAlert } from 'react-confirm-alert';
+import 'react-confirm-alert/src/react-confirm-alert.css';
 import { fetchUserRecipes, deleteRecipe } from '../../actions/recipeActions';
 import RecipeList from './RecipeList';
 
@@ -26,7 +28,14 @@ class UserRecipesPage extends Component {
     }
   }
   handleDeleteRecipe(id) {
-    this.props.deleteRecipe(id);
+    confirmAlert({
+      title: 'Confirm to Delete',
+      message: 'Are you sure you want to delete this recipe?',
+      confirmLabel: 'Yes, delete',
+      cancelLabel: 'Do not delete',
+      onConfirm: () => this.props.deleteRecipe(id),
+      onCancel: () => this.props.history.push('/myRecipes'),
+    });
   }
   render() {
     this.isSignedIn();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10704,6 +10704,11 @@
         "warning": "3.0.0"
       }
     },
+    "react-confirm-alert": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-1.0.8.tgz",
+      "integrity": "sha1-E8u889mSokWzFe8YzCA4JVbj8DM="
+    },
     "react-deep-force-update": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.1.1",
     "react-bootstrap": "^0.31.5",
+    "react-confirm-alert": "^1.0.8",
     "react-dom": "^16.1.1",
     "react-hot-loader": "^3.1.3",
     "react-paginate": "^5.0.0",

--- a/server/test/3_favoritesTest.js
+++ b/server/test/3_favoritesTest.js
@@ -135,7 +135,7 @@ describe('test favorites actions', () => {
         expect('Content-Type', /json/);
         expect(res.statusCode).to.equal(200);
         expect(res.body.status).to.equal('success');
-        expect(res.body.message).to.equal('You hav successfully added this recipe to your favorites.');
+        expect(res.body.message).to.equal('You have successfully added this recipe to your favorites.');
         if (err) return done(err);
         done();
       });
@@ -149,7 +149,7 @@ describe('test favorites actions', () => {
         expect('Content-Type', /json/);
         expect(res.statusCode).to.equal(200);
         expect(res.body.status).to.equal('success');
-        expect(res.body.message).to.equal('You hav successfully added this recipe to your favorites.');
+        expect(res.body.message).to.equal('You have successfully added this recipe to your favorites.');
         if (err) return done(err);
         done();
       });


### PR DESCRIPTION
 #### What does this PR do?
- Enables users to confirm their recipe delete action
#### Description of Task to be completed?
- Install react-confirm-alert package
- configure the alert in the UserRecipesPage component
#### How should this be manually tested?
- Start the app with the command `npm run start:dev`
- Go to the port 8000
- Create a user account or log in to an existing account
- At the add a recipe to the catalog and attempt to delete it.
- a dialog will come up prompting you to confirm your action
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
 - fearture/155552363/Add-confirm-functionality-to-delete-action
#### Screenshots (if appropriate)

#### Questions:
N/A

[ Finishes #155552363 ]